### PR TITLE
Missing global scope on JSZip, JSZipUtils and pica

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -1,6 +1,6 @@
-var pica = new pica();
-var zip = new JSZip();
-var data = [];
+const pica = new window.pica();
+const zip = new window.JSZip();
+const data = [];
 
 function postEmotes() {
     let files = document.getElementById('emote-files').files;
@@ -111,14 +111,12 @@ function resize(container, size, path) {
 }
 
 function urlToPromise(url) {
-    return new Promise(function (resolve, reject) {
-        JSZipUtils.getBinaryContent(url, function(err, data) {
-            if (err)
-                reject(err);
-            else
-                resolve(data);
-        });
+  return new Promise(function (resolve, reject) {
+    window.JSZipUtils.getBinaryContent(url, function (err, data) {
+      if (err) reject(err);
+      else resolve(data);
     });
+  });
 }
 
 function downloadAll() {


### PR DESCRIPTION
I'm currently getting a reference error when I open the page in Edge –

![image](https://user-images.githubusercontent.com/18070845/147513489-29d2d586-4105-4e29-8c54-6bbdf593a810.png)

I've updated them on to a global scope, and it fixed it; but I would suggest setting everything in `js/index.js` either in a [DOMContentLoaded](https://developer.mozilla.org/en-US/docs/Web/API/Window/DOMContentLoaded_event) event or adding an `defer` [attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script#attr-defer) to the import of the `js/index.js` script.